### PR TITLE
pequena traducao na introducao => site web2py

### DIFF
--- a/sources/31-web2py-portuguese/01.markmin
+++ b/sources/31-web2py-portuguese/01.markmin
@@ -25,7 +25,7 @@ FireBird ``firebird``:cite Oracle ``oracle``:cite , IBM DB2 ``db2``:cite , Infor
 O DAL também pode gerar chamadas de função para o Google Datastore
 quando executado no Google App Engine (GAE) ``gae``:cite .
 Experimentalmente suportamos mais bancos de dados e novos são constantemente adicionados.
-Por favor, verifique no web2py site e lista de discussão para adaptadores mais recentes.
+Por favor, verifique no site do web2py e lista de discussão para adaptadores mais recentes.
 Quando uma ou mais tabelas de banco de dados são definidas, o web2py gera automaticamente um banco de dados totalmente funcional baseado na web
 interface de administração para acessar o banco de dados e as tabelas.
 


### PR DESCRIPTION
de `verifique no web2py site` para `verifique no site do web2py`
